### PR TITLE
Fix eval error

### DIFF
--- a/functions/get.fish
+++ b/functions/get.fish
@@ -70,7 +70,7 @@ function get -d "Press any key to continue..."
         set prompt "$prompt "
     end
 
-    if test "$count" -le 0
+    if test $count -le 0
         set -e count
     end
 

--- a/functions/get.fish
+++ b/functions/get.fish
@@ -70,7 +70,7 @@ function get -d "Press any key to continue..."
         set prompt "$prompt "
     end
 
-    if test $count -le 0
+    if test -z "$count"; or test $count -le 0
         set -e count
     end
 


### PR DESCRIPTION
Resolves #4 

`$count` is treated as an integer in the test, but when it is empty (the way it starts) this causes problems with the "less than zero" check due to the empty string.

```fish
$ test "" -le 0
test returned eval errors:
	invalid integer ''
```

Removing the quotes just changes the error.

```fish
$  test  -le 0
test: Missing argument at index 2
```

It looks like an empty `$count` has meaning, so rather than initialize it to zero, I added an empty string check.